### PR TITLE
ルーティングを設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -2132,6 +2132,12 @@
         }
       }
     },
+    "@types/history": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
+      "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==",
+      "dev": true
+    },
     "@types/html-minifier-terser": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
@@ -2158,6 +2164,15 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.23",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -2172,6 +2187,11 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
+    },
+    "@types/node": {
+      "version": "12.20.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.13.tgz",
+      "integrity": "sha512-1x8W5OpxPq+T85OUsHRP6BqXeosKmeXRtjoF39STcdf/UWLqUsoehstZKOi0CunhVqHG17AyZgpj20eRVooK6A=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2226,6 +2246,27 @@
             "csstype": "^3.0.2"
           }
         }
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.14",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.14.tgz",
+      "integrity": "sha512-LAJpqYUaCTMT2anZheoidiIymt8MuX286zoVFPM3DVb23aQBH0mAkFvzpd4LKqiolV8bBtZWT5Qp7hClCNDENw==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.7.tgz",
+      "integrity": "sha512-D5mHD6TbdV/DNHYsnwBTv+y73ei+mMjrkGrla86HthE4/PVvL1J94Bu3qABU+COXzpL23T1EZapVVpwHuBXiUg==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/react-router-dom": "^5.1.7"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,39 @@
 import React from 'react';
-import logo from './logo.svg';
 import './App.css';
+import {
+  BrowserRouter as Router,
+  Switch,
+  Route,
+  Link
+} from 'react-router-dom';
+import Header from './components/Header';
+import Index from './pages/Index';
+import PixelArtsTemplates from './pages/PixelArtsTemplates';
+import PixelArtsEdit from './pages/PixelArtsEdit';
+import PixelArtsMe from './pages/PixelArtsMe';
+import PixelArtsPreview from './pages/PixelArtsPreview';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+    <div className='App'>
+      <Router>
+        <Header />
+        <Switch>
+          {/* プレビュー画面 ':id'で指定されたドット絵を表示 */}
+          <Route path='/pixel-arts/:id' component={PixelArtsPreview} />
+          {/* 作成したドット絵一覧 */}
+          <Route path='/pixel-arts-me' component={PixelArtsMe} />
+          {/* ドット絵編集画面(新規) */}
+          <Route path='/pixel-arts-edit' component={PixelArtsEdit} />
+          {/* ドット絵編集画面(既存) :id'で指定されたドット絵を表示  */}
+          <Route path='/pixel-arts-edit/:id' component={PixelArtsEdit} />
+          {/* 作成したドット絵一覧 */}
+          <Route path='/pixel-arts-templates' component={PixelArtsTemplates} />
+          {/* ホーム画面 */}
+          <Route path='/' component={Index} />
+          <Route component={Index} />
+        </Switch>
+      </Router>
     </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { AppBar, Typography } from '@material-ui/core';
+
+const Header = () => {
+  return (
+    <AppBar position="static">
+      <Typography variant="h6">
+        Header 参考URL https://material-ui.com/components/app-bar/
+    </Typography>
+    </AppBar>
+  );
+}
+
+export default Header

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Index = () => {
+  return (
+    <div>ホーム画面</div>
+  );
+}
+
+export default Index

--- a/src/pages/PixelArtsEdit.tsx
+++ b/src/pages/PixelArtsEdit.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const PixelArtsEdit = () => {
+  return (
+    <div>ドット絵編集画面</div>
+  );
+}
+
+export default PixelArtsEdit;

--- a/src/pages/PixelArtsMe.tsx
+++ b/src/pages/PixelArtsMe.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const PixelArtsMe = () => {
+  return (
+    <div>作成したドット絵一覧画面</div>
+  );
+}
+
+export default PixelArtsMe;

--- a/src/pages/PixelArtsPreview.tsx
+++ b/src/pages/PixelArtsPreview.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const PixelArtsPreview = () => {
+  return (
+    <div>プレビュー画面</div>
+  );
+}
+
+export default PixelArtsPreview;

--- a/src/pages/PixelArtsTemplates.tsx
+++ b/src/pages/PixelArtsTemplates.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const PixelArtsTemplates = () => {
+  return (
+    <div>テンプレート選択画面</div>
+  );
+}
+
+export default PixelArtsTemplates;


### PR DESCRIPTION
## 設定したルーティングは下記を参考
### 下記のURL以外を参照した場合は、ホーム画面に飛ばすように設定
### [ルーティングファイル ](https://github.com/kbc18a11/dotpika-front/pull/1/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2)
- /
  - ホーム画面   **兵頭担当**　ヘッダーも担当
- /pixel-arts/:id
  -  プレビュー画面 ':id'で指定されたドット絵を表示 **津田担当**
- /pixel-arts-me
  -  作成したドット絵一覧 **筒井担当**
- /pixel-arts-edit
  -  ドット絵編集画面(新規) **村瀬担当**
- /pixel-arts-edit/:id
  - ドット絵編集画面(既存) :id'で指定されたドット絵を表示 **村瀬担当**
- /pixel-arts-templates
  - テンプレートのドット絵一覧  **安藤担当**